### PR TITLE
Refactor default model namespaces

### DIFF
--- a/DictionaryBuilder/Options/VisualStudioOptions.cs
+++ b/DictionaryBuilder/Options/VisualStudioOptions.cs
@@ -23,11 +23,11 @@ namespace DictionaryBuilder
         public const EncryptionMethod DEFAULT_ENCRYPTION_METHOD = EncryptionMethod.Common;
         public const string DEFAULT_NAMESPACE = "{project}.{path}";
         public const string DEFAULT_CULTURE_MODEL_PATH = "/Models/Dictionary/UmbracoCulture.cs";
-        public const string DEFAULT_CULTURE_MODEL_NAMESPACE = "Umbraco.Core.Models.Language";
+        public const string DEFAULT_CULTURE_MODEL_NAMESPACE = "Umbraco.Core.Models";
         public const string DEFAULT_DICTIONARY_MODEL_PATH = "/Models/Dictionary/Dictionary.cs";
-        public const string DEFAULT_DICTIONARY_MODEL_NAMESPACE = "Umbraco.Core.Models.Dictionary";
+        public const string DEFAULT_DICTIONARY_MODEL_NAMESPACE = "Umbraco.Core.Models";
         public const string DEFAULT_DICTIONARYKEY_MODEL_PATH = "/Models/Dictionary/DictionaryKey.cs";
-        public const string DEFAULT_DICTIONARYKEY_MODEL_NAMESPACE = "Umbraco.Core.Models.Dictionary";
+        public const string DEFAULT_DICTIONARYKEY_MODEL_NAMESPACE = "Umbraco.Core.Models";
         public const string DEFAULT_SERVICE_PATH = "/Services/Implement/DictionaryService.cs";
         public const string DEFAULT_SERVICE_NAMESPACE = "Umbraco.Core.Services.Implement";
         public const string DEFAULT_ISERVICE_PATH = "/Services/IDictionaryService.cs";


### PR DESCRIPTION
# Description

- Refactors the default model namespaces.
- Resolves an issue where the language namespace used by the **UmbracoCulture** class conflicts with the **Umbraco.Core.Language** model.

### Type of change

Tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Where should the reviewer start?

- Clone the branch
- Run the project in Visual Studio

## How should this be tested?

1. Navigate to **Options > Umbraco > DictionaryBuilder Options**.
2. Observe the default namespace for all models is now: `Umbraco.Core.Models`.
3. Right click the project in Solution Explorer.
4. Run the **Umbraco Dictionary > Rebuild Dictionary** command.
5. Locate the exported dictionary models.
6. Sense check the namespace of all models.